### PR TITLE
Update to version 2.2

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Flutter (1.0.0)
-  - flutter_native_text_input (2.1.0):
+  - flutter_native_text_input (2.2.0):
     - Flutter
 
 DEPENDENCIES:
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  flutter_native_text_input: ce34c74884f3d4c9e1a6daf9bc2d0bea66a62c49
+  flutter_native_text_input: 246da758e5a2e744774aa839a1a21902e0e84ceb
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -72,10 +72,12 @@ packages:
   flutter_native_text_input:
     dependency: "direct main"
     description:
-      name: flutter_native_text_input
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
+      path: "."
+      ref: uitextview-placeholder
+      resolved-ref: "991675aa2381d656aad953f468ab7251c134432d"
+      url: "https://github.com/collinjackson/flutter-native-text-input"
+    source: git
+    version: "2.2.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -115,7 +117,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -162,7 +164,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,8 +29,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_native_text_input: ^2.1.1
-
+  flutter_native_text_input:
+    git:
+      url: https://github.com/collinjackson/flutter-native-text-input
+      ref: uitextview-placeholder
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2


### PR DESCRIPTION
Updates to use flutter_native_text_input 2.2.0, which has not yet been published. This will allow you to see the improvements to placeholder.

https://user-images.githubusercontent.com/394889/159539109-ecb821bc-a8b3-4d17-b0b9-6384715ff88a.mp4

